### PR TITLE
Add 'bacon-frying' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Bacon status](https://img.shields.io/badge/bacon-frying-brightgreen.svg)](http://www.jupiterbroadcasting.com/show/unfilter/)
+
 OpenYourMouth
 =============
 


### PR DESCRIPTION
This adds a shield/badge to README.md with the text 'bacon-frying'.

The service provided by http://shields.io/ is used to generate the badge.

This parodies the badges used by many open-source projects on GitHub,
the image links to the Unfilter show page on jupiterbroadcasting.com
as a homage to the the origin of the phrase 'frying (conspiracy) bacon'.
## 

I don't expect this to be merged, unless you like it!
Either way, I thought the README could do with a bit of colour,
maybe there are other ideas for adding something like this?
